### PR TITLE
Add HP ring Chrome extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,112 @@
+let USE_STATIC_HP=true;
+const STATIC_HP=72;
+const MOCK_POINTS=[
+ {t:"2025-08-26T08:00:00+09:00",hp:100},
+ {t:"2025-08-26T12:00:00+09:00",hp:80},
+ {t:"2025-08-26T16:00:00+09:00",hp:60},
+ {t:"2025-08-26T20:00:00+09:00",hp:40},
+ {t:"2025-08-27T00:00:00+09:00",hp:20}
+];
+let wrap,progress,percent,sub,c;
+function create(){
+ if(document.getElementById("hp-ext-widget"))return;
+ wrap=document.createElement("div");
+ wrap.id="hp-ext-widget";
+ wrap.style.cursor="grab";
+ const svg=document.createElementNS("http://www.w3.org/2000/svg","svg");
+ svg.setAttribute("viewBox","0 0 100 100");
+ svg.style.transform="rotate(-90deg)";
+ svg.style.transformOrigin="50% 50%";
+ const bg=document.createElementNS("http://www.w3.org/2000/svg","circle");
+ bg.setAttribute("cx","50");
+ bg.setAttribute("cy","50");
+ bg.setAttribute("r","45");
+ bg.setAttribute("class","ring-bg");
+ progress=document.createElementNS("http://www.w3.org/2000/svg","circle");
+ progress.setAttribute("cx","50");
+ progress.setAttribute("cy","50");
+ progress.setAttribute("r","45");
+ progress.setAttribute("class","ring-fg");
+ svg.appendChild(bg);
+ svg.appendChild(progress);
+ wrap.appendChild(svg);
+ const center=document.createElement("div");
+ center.className="hp-center";
+ percent=document.createElement("div");
+ percent.className="hp-percent";
+ center.appendChild(percent);
+ wrap.appendChild(center);
+ sub=document.createElement("div");
+ sub.className="hp-sub";
+ wrap.appendChild(sub);
+ document.body.appendChild(wrap);
+ c=2*Math.PI*45;
+ progress.style.strokeDasharray=c;
+ progress.style.strokeDashoffset=c;
+}
+function update(){
+ const hp=getHP();
+ percent.textContent=hp+"%";
+ progress.style.strokeDashoffset=c*(100-hp)/100;
+ progress.style.stroke=hp>=60?"#4caf50":hp>=30?"#ff9800":"#f44336";
+ sub.textContent=USE_STATIC_HP?"mock":new Date().toLocaleTimeString([], {hour:"2-digit",minute:"2-digit"});
+}
+function getHP(){
+ if(USE_STATIC_HP)return STATIC_HP;
+ const now=new Date();
+ let last=MOCK_POINTS[0].hp;
+ for(const p of MOCK_POINTS){
+  const pt=new Date(p.t);
+  if(pt<=now)last=p.hp;else break;
+ }
+ return last;
+}
+function load(){
+ chrome.storage.sync.get(["hpExtPos","hpExtMode"],res=>{
+  if(res.hpExtPos){
+   wrap.style.left=res.hpExtPos.left+"px";
+   wrap.style.top=res.hpExtPos.top+"px";
+  }else{
+   wrap.style.right="16px";
+   wrap.style.bottom="16px";
+  }
+  USE_STATIC_HP=res.hpExtMode==="timeline"?false:true;
+  update();
+ });
+}
+function drag(){
+ let sx,sy,dragging=false;
+ wrap.addEventListener("mousedown",e=>{
+  e.preventDefault();
+  const r=wrap.getBoundingClientRect();
+  sx=e.clientX-r.left;
+  sy=e.clientY-r.top;
+  wrap.style.left=r.left+"px";
+  wrap.style.top=r.top+"px";
+  wrap.style.right="";
+  wrap.style.bottom="";
+  dragging=true;
+  wrap.style.cursor="grabbing";
+ });
+ document.addEventListener("mousemove",e=>{
+  if(!dragging)return;
+  wrap.style.left=e.clientX-sx+"px";
+  wrap.style.top=e.clientY-sy+"px";
+ });
+ document.addEventListener("mouseup",()=>{
+  if(!dragging)return;
+  dragging=false;
+  wrap.style.cursor="grab";
+  chrome.storage.sync.set({hpExtPos:{left:parseInt(wrap.style.left),top:parseInt(wrap.style.top)}});
+ });
+}
+create();
+load();
+drag();
+chrome.storage.onChanged.addListener(ch=>{
+ if(ch.hpExtMode){
+  USE_STATIC_HP=ch.hpExtMode.newValue==="timeline"?false:true;
+  update();
+ }
+});
+setInterval(update,30000);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+ "manifest_version": 3,
+ "name": "HPリング",
+ "version": "1.0",
+ "description": "HPリングを表示",
+ "permissions": ["storage","tabs"],
+ "action": {"default_popup": "popup.html"},
+ "content_scripts": [{
+  "matches": ["<all_urls>"],
+  "js": ["content.js"],
+  "css": ["overlay.css"]
+ }]
+}

--- a/overlay.css
+++ b/overlay.css
@@ -1,0 +1,7 @@
+#hp-ext-widget{position:fixed;width:88px;height:88px;z-index:2147483647;font-family:sans-serif;}
+#hp-ext-widget svg{width:100%;height:100%;}
+#hp-ext-widget .ring-bg{fill:none;stroke:#e0e0e0;stroke-width:10;}
+#hp-ext-widget .ring-fg{fill:none;stroke-width:10;}
+#hp-ext-widget .hp-center{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;}
+#hp-ext-widget .hp-percent{font-weight:bold;font-size:22px;}
+#hp-ext-widget .hp-sub{position:absolute;bottom:4px;width:100%;text-align:center;font-size:10px;}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>HP</title>
+</head>
+<body>
+<button id="reload">今すぐ更新</button>
+<button id="mode"></button>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,21 @@
+document.addEventListener("DOMContentLoaded",()=>{
+ const reload=document.getElementById("reload");
+ const mode=document.getElementById("mode");
+ function setText(m){mode.textContent=m==="static"?"タイムライン表示":"固定72%表示";}
+ chrome.storage.sync.get(["hpExtMode"],res=>{
+  const m=res.hpExtMode||"static";
+  mode.dataset.mode=m;
+  setText(m);
+ });
+ reload.addEventListener("click",()=>{
+  chrome.tabs.query({active:true,currentWindow:true},tabs=>{
+   if(tabs[0])chrome.tabs.reload(tabs[0].id);
+  });
+ });
+ mode.addEventListener("click",()=>{
+  const m=mode.dataset.mode==="static"?"timeline":"static";
+  chrome.storage.sync.set({hpExtMode:m});
+  mode.dataset.mode=m;
+  setText(m);
+ });
+});


### PR DESCRIPTION
## Summary
- add Manifest V3 extension showing draggable HP ring overlay with static or timeline data
- include popup controls for reloading tab and switching modes, saving settings via chrome.storage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68adb8bcce248329984f8efe7af9320f