### PR TITLE
Add settings gear button and options UI scaffolding

### DIFF
--- a/content.js
+++ b/content.js
@@ -39,6 +39,13 @@ function create(){
  sub=document.createElement("div");
  sub.className="hp-sub";
  wrap.appendChild(sub);
+ const gear=document.createElement("div");
+ gear.className="gear-btn";
+ gear.textContent="⚙";
+ gear.title="設定";
+ gear.addEventListener("click",e=>{e.stopPropagation();chrome.runtime.openOptionsPage();});
+ gear.addEventListener("mousedown",e=>e.stopPropagation());
+ wrap.appendChild(gear);
  document.body.appendChild(wrap);
  c=2*Math.PI*45;
  progress.style.strokeDasharray=c;

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
  "description": "HPリングを表示",
  "permissions": ["storage","tabs"],
  "action": {"default_popup": "popup.html"},
+ "options_page": "options.html",
  "content_scripts": [{
   "matches": ["<all_urls>"],
   "js": ["content.js"],

--- a/options.html
+++ b/options.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>設定</title>
+<style>
+ body{font-family:system-ui;margin:0;padding:16px;background:#f5f5f5;}
+ .card{background:#fff;padding:20px;border-radius:8px;max-width:480px;margin:auto;display:flex;flex-direction:column;gap:24px;}
+ section{display:flex;flex-direction:column;gap:8px;}
+ .uid-row,.slider-row,.toggle-row{display:flex;align-items:center;gap:8px;}
+ input[type=text]{flex:1;padding:4px;}
+ button{padding:4px 8px;}
+ .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:8px 16px;border-radius:4px;opacity:0;transition:opacity .3s;}
+ .toast.show{opacity:1;}
+</style>
+</head>
+<body>
+<div class="card">
+  <section>
+    <h2>現在のUID（コピー）</h2>
+    <div class="uid-row">
+      <input id="uid" type="text" readonly>
+      <button id="copy-btn">コピー</button>
+    </div>
+  </section>
+  <section>
+    <h2>位置情報の登録（任意）</h2>
+    <button id="loc-btn">位置情報を登録</button>
+  </section>
+  <section>
+    <h2>HPしきい値（20% 初期値）</h2>
+    <div class="slider-row">
+      <input id="hp-threshold" type="range" min="0" max="50" value="20">
+      <span id="hp-val">20%</span>
+    </div>
+  </section>
+  <section>
+    <h2>フィードバックON/OFF（1日1回チェックイン）</h2>
+    <div class="toggle-row">
+      <input id="feedback-toggle" type="checkbox">
+      <span id="fb-label">OFF</span>
+    </div>
+  </section>
+</div>
+<div id="toast" class="toast"></div>
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded',()=>{
+ const uidInput=document.getElementById('uid');
+ const copyBtn=document.getElementById('copy-btn');
+ const locBtn=document.getElementById('loc-btn');
+ const slider=document.getElementById('hp-threshold');
+ const hpVal=document.getElementById('hp-val');
+ const toggle=document.getElementById('feedback-toggle');
+ const fbLabel=document.getElementById('fb-label');
+ uidInput.value='未登録';
+ hpVal.textContent=slider.value+'%';
+ copyBtn.addEventListener('click',async()=>{
+  try{
+   await navigator.clipboard.writeText(uidInput.value);
+   const t=copyBtn.textContent;
+   copyBtn.textContent='コピーしました';
+   setTimeout(()=>copyBtn.textContent=t,2000);
+  }catch(e){}
+ });
+ locBtn.addEventListener('click',()=>{showToast('位置登録は未実装です');});
+ slider.addEventListener('input',()=>{hpVal.textContent=slider.value+'%';});
+ toggle.addEventListener('change',()=>{fbLabel.textContent=toggle.checked?'ON':'OFF';});
+});
+function showToast(msg){
+ const toast=document.getElementById('toast');
+ toast.textContent=msg;
+ toast.classList.add('show');
+ setTimeout(()=>toast.classList.remove('show'),2000);
+}

--- a/overlay.css
+++ b/overlay.css
@@ -5,3 +5,5 @@
 #hp-ext-widget .hp-center{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;}
 #hp-ext-widget .hp-percent{font-weight:bold;font-size:22px;}
 #hp-ext-widget .hp-sub{position:absolute;bottom:4px;width:100%;text-align:center;font-size:10px;}
+#hp-ext-widget .gear-btn{position:absolute;top:6px;right:6px;width:24px;height:24px;border-radius:50%;background:rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;cursor:pointer;transition:background .2s;}
+#hp-ext-widget .gear-btn:hover{background:rgba(0,0,0,.6);}


### PR DESCRIPTION
## Summary
- Add gear button to HP overlay opening the options page
- Include manifest options_page and styling for the new gear button
- Build stubbed options page with UID copy, location registration, HP threshold slider, and feedback toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcb22761083299fa30454e3097d49